### PR TITLE
Update README.md - chain only on iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ Chain a sequence of iterables:
 >>>
 ```
 
-Warning : chain only unfold iterable containing ONLY iterables:
+Warning : chain only unfolds an iterable containing ONLY iterables:
 
 ```python
-[1, 2, [3]] | chain
+list([1, 2, [3]] | chain)
 ```
-Gives a `TypeError: chain argument #1 must support iteration`
+Gives a `TypeError: 'int' object is not iterable`
 Consider using traverse.
 
 


### PR DESCRIPTION
update the documentation in the readme file
chain only applies to iterables, but the error is raised only when the `chain`ed object is iterated over, for example by converting to a `list`